### PR TITLE
Add script to recursively run Add-ARPEntries.ps1

### DIFF
--- a/Recurse.ps1
+++ b/Recurse.ps1
@@ -1,0 +1,20 @@
+Param(
+    [Parameter(Mandatory = $true, Position = 0, HelpMessage = "The directory to recurse through.")] 
+    [String] $DirectoryPath
+)
+
+Set-Location $DirectoryPath
+$PackageName = Get-ChildItem -Path $path -Force -Recurse -File | Select-Object -First 1 | Select-Object -ExpandProperty Name
+$PackageName = $PackageName -replace ".installer.yaml","" -replace '\.', ' '
+$CommitTitle = “Add ARP Entries for $PackageName"
+Get-ChildItem -Recurse -File -Filter *.installer.yaml | ForEach-Object {
+    .$PSScriptRoot/Add-ARPEntries.ps1 $_.PSParentPath -NoDenormalizeInstallerTypes
+    $BranchName = New-Guid
+    git switch upstream/master --detach --quiet
+    git add .
+    git commit --message=$CommitTitle
+    git switch --create $BranchName
+    git push --set-upstream origin $BranchName
+    gh pr create --title $CommitTitle --body "### Pull request has been automatically created using [Add-ARPEntries](https://github.com/jedieaston/Add-ARPEntries)"
+}
+Set-Location $PSScriptRoot


### PR DESCRIPTION
### This pull request adds a script that recursively runs [Add-ARPEntries.ps1](https://github.com/jedieaston/Add-ARPEntries/blob/master/Add-ARPEntries.ps1) for a directory.

It has one mandatory parameter which is the directory to recurse through:

```powershell
.\Recurse C:\User\winget-pkgs\manifests\p\Publisher\Package
```
This must be the folder that contains all the versions of a package, not any subfolder, as it will run through all of the subfolders.

It retrieves the package name by going to the first item within the directory (Publisher.Package.Version.installer.yaml), removes the `installer.yaml` and replaces the `.` with ` `.

This is what a pull request made with Recurse.ps1 looks like:

![firefox_NoYqNkErFX](https://user-images.githubusercontent.com/74878137/187009722-db1f2107-c689-4ea8-ba41-42bb3a33be9d.png)

This is my first PowerShell script so there will be improvements as I learn; I'll make PRs when necessary :)
