### PR TITLE
Add validation and cleanup for Recurse.ps1

### DIFF
--- a/Recurse.ps1
+++ b/Recurse.ps1
@@ -1,15 +1,86 @@
+#Requires -Version 5
+
 Param(
-    [Parameter(Mandatory = $true, Position = 0, HelpMessage = "The directory to recurse through.")] 
+    [Parameter(Mandatory = $true, HelpMessage = "The directory to recurse through.")] 
     [String] $DirectoryPath
 )
 
+# Check if Docker is running
+docker ps | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Docker isn't running. Start it up (and make sure it's in Windows mode) before continuing!" -ForegroundColor Red
+    exit
+}
+
+# Check if git is installed
+try {
+    git | Out-Null
+} catch [System.Management.Automation.CommandNotFoundException] {
+    Write-Host "Git is not installed." -ForegroundColor Red
+    exit
+}
+
+# Check if GitHub CLI is installed
+try {
+    gh | Out-Null
+} catch [System.Management.Automation.CommandNotFoundException] {
+    Write-Host "GitHub CLI is not installed." -ForegroundColor Red
+    exit
+}
+
+# If the user has git installed, make sure it is a patched version
+if (Get-Command 'git.exe' -ErrorAction SilentlyContinue) {
+    $GitMinimumVersion = [System.Version]::Parse('2.35.2')
+    $gitVersionString = ((git version) | Select-String '([0-9]{1,}\.){3,4}').Matches.Value.Trim(' ', '.')
+    $gitVersion = [System.Version]::Parse($gitVersionString)
+    if ($gitVersion -lt $GitMinimumVersion) {
+        # Prompt user to install git
+        if (Get-Command 'winget.exe' -ErrorAction SilentlyContinue) {
+            $_menu = @{
+                entries       = @('[Y] Upgrade Git'; '[N] Do not upgrade')
+                Prompt        = 'The version of git installed on your machine does not satisfy the requirement of version >= 2.35.2; Would you like to upgrade?'
+                HelpText      = "Upgrading will attempt to upgrade git using winget`n"
+                DefaultString = ''
+            }
+            switch (Invoke-KeypressMenu -Prompt $_menu['Prompt'] -Entries $_menu['Entries'] -DefaultString $_menu['DefaultString'] -HelpText $_menu['HelpText']) {
+                'Y' { 
+                    Write-Host
+                    try {
+                        winget upgrade --id Git.Git --exact
+                    } catch {
+                        throw [UnmetDependencyException]::new('Git could not be upgraded sucessfully', $_)
+                    } finally {
+                        $gitVersionString = ((git version) | Select-String '([0-9]{1,}\.){3,4}').Matches.Value.Trim(' ', '.')
+                        $gitVersion = [System.Version]::Parse($gitVersionString)
+                        if ($gitVersion -lt $GitMinimumVersion) {
+                            throw [UnmetDependencyException]::new('Git could not be upgraded sucessfully')
+                        }
+                    }
+                 }
+                default { Write-Host; throw [UnmetDependencyException]::new('The version of git installed on your machine does not satisfy the requirement of version >= 2.35.2') }
+            }
+        } else {
+            throw [UnmetDependencyException]::new('The version of git installed on your machine does not satisfy the requirement of version >= 2.35.2')
+        }
+    }
+    # Check whether the script is present inside a fork/clone of jedieaston/Add-ARPEntries repository
+    try {
+        $script:gitTopLevel = (Resolve-Path $(git rev-parse --show-toplevel)).Path
+    } catch {
+        # If there was an exception, the user isn't in a git repo. Throw a custom exception and pass the original exception as an InternalException
+        throw [UnmetDependencyException]::new('This script must be run from inside a clone of the Add-ARPEntries repository', $_.Exception)
+    }
+}
+
 Set-Location $DirectoryPath
-$PackageName = Get-ChildItem -Path $path -Force -Recurse -File | Select-Object -First 1 | Select-Object -ExpandProperty Name
-$PackageName = $PackageName -replace ".installer.yaml","" -replace '\.', ' '
-$CommitTitle = “Add ARP Entries for $PackageName"
+$PackageIdentifier = Get-ChildItem -Path $path -Force -Recurse -File | Select-Object -First 1 | Select-Object -ExpandProperty Name
+$PackageIdentifier = $PackageIdentifier -replace ".installer.yaml",""
 Get-ChildItem -Recurse -File -Filter *.installer.yaml | ForEach-Object {
+    $PackageVersion = Split-Path $_.PSParentPath -Leaf
+    $CommitTitle = "ARP Entries: $PackageIdentifier version $PackageVersion"
+    $FileHash = Get-ChildItem -Path $_.PSParentPath -Force -Recurse -File | Select-Object -First 1 | Get-FileHash
+    $BranchName = "$PackageIdentifier-$($FileHash.Hash[0..14] -Join '')"
     .$PSScriptRoot/Add-ARPEntries.ps1 $_.PSParentPath -NoDenormalizeInstallerTypes
-    $BranchName = New-Guid
     git switch upstream/master --detach --quiet
     git add .
     git commit --message=$CommitTitle

--- a/Recurse.ps1
+++ b/Recurse.ps1
@@ -79,7 +79,7 @@ Get-ChildItem -Recurse -File -Filter *.installer.yaml | ForEach-Object {
     $PackageVersion = Split-Path $_.PSParentPath -Leaf
     $CommitTitle = "ARP Entries: $PackageIdentifier version $PackageVersion"
     $FileHash = Get-ChildItem -Path $_.PSParentPath -Force -Recurse -File | Select-Object -First 1 | Get-FileHash
-    $BranchName = "$PackageIdentifier-$($FileHash.Hash[0..14] -Join '')"
+    $BranchName = "$PackageIdentifier-$PackageVersion-$($FileHash.Hash[0..14] -Join '')"
     .$PSScriptRoot/Add-ARPEntries.ps1 $_.PSParentPath -NoDenormalizeInstallerTypes
     git switch upstream/master --detach --quiet
     git add .


### PR DESCRIPTION
This PR adds validation for Recurse.ps1:

1. Check that docker is running (rather than failing when Add-ARPEntries checks and then creating random branches and committing nothing).
2. Check Git is installed.
3. Check that GItHub CLI is installed.
4. If Git is installed, check that it is a patched version and prompt the user to update with winget if they are outdated (code extract taken from [YamlCreate.ps1](https://github.com/microsoft/winget-pkgs/blob/master/Tools/YamlCreate.ps1)).

Alongside this, it improves the title and branch name to the standard of YamlCreate, specifying the version. The branch name is generated in an almost identical fashion to YamlCreate, rather than generating a random GUID:

![firefox_lfsA4dX2el](https://user-images.githubusercontent.com/74878137/187045780-e6e1fc5c-66c7-4fac-91e8-566ebe8bd505.png)