### PR TITLE
Make Recurse.ps1 retrieve the package name for every loop

### DIFF
--- a/Recurse.ps1
+++ b/Recurse.ps1
@@ -73,9 +73,9 @@ if (Get-Command 'git.exe' -ErrorAction SilentlyContinue) {
 }
 
 Set-Location $DirectoryPath
-$PackageIdentifier = Get-ChildItem -Path $path -Force -Recurse -File | Select-Object -First 1 | Select-Object -ExpandProperty Name
-$PackageIdentifier = $PackageIdentifier -replace ".installer.yaml",""
 Get-ChildItem -Recurse -File -Filter *.installer.yaml | ForEach-Object {
+    $PackageIdentifier = Get-ChildItem -Path $_.PSParentPath -File | Select-Object -First 1 | Select-Object -ExpandProperty Name
+    $PackageIdentifier = $PackageIdentifier -replace ".installer.yaml",""
     $PackageVersion = Split-Path $_.PSParentPath -Leaf
     $CommitTitle = "ARP Entries: $PackageIdentifier version $PackageVersion"
     $FileHash = Get-ChildItem -Path $_.PSParentPath -Force -Recurse -File | Select-Object -First 1 | Get-FileHash


### PR DESCRIPTION
This PR simply makes Recurse.ps1 retrieve the package name for every loop rather than before starting recursion. This means that the script can be ran on larger directories, and show the correct name in the PR.

For example, if you previously ran the script on `Azul.Zulu.8` (which contains `Azul.Zulu.8.JDK` and `Azul.Zulu.8.JRE`), it would recurse through both those packages and their versions, but the PR would say it was for the JDK variation (as that is the first package it reaches when recursing). This now means that it will give the correct name when ran on larger directories.